### PR TITLE
Only show visible repositories in sidebar

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -32,7 +32,7 @@ class Repository < ActiveRecord::Base
 
   validates_uniqueness_of :github_name
 
-  scope :latest, where("builds_count > 0").order("last_build_at desc")
+  scope :latest, where("visible = true and builds_count > 0").order("last_build_at desc")
 
   delegate :email, to: :user, prefix: true
 


### PR DESCRIPTION
I see my repository is still in sidebar after my setting visible to false, please merge this request if it's ok.
