### PR TITLE
Auto corrected by following Lint Ruby Performance/RedundantMerge

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -27,7 +27,7 @@ Rollbar.configure do |config|
   # via the rollbar interface.
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
-  config.exception_level_filters.merge!('ActionController::RoutingError' => 'ignore')
+  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
   #
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })


### PR DESCRIPTION
Auto corrected by following Lint Ruby Performance/RedundantMerge

Click [here](https://awesomecode.io/repos/flyerhzm/rails-brakeman.com/lint_configs/ruby/54339) to configure it on awesomecode.io